### PR TITLE
Release 3.0.0: migrate to Dart 3 & Gradle 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Current release
 
+## [3.0.0] - 10 June 2024
+### Release Notes:
+* BREAKING: Major version update to 3.0.0.
+* Updated Dart SDK constraint to ^3.10.7.
+* Minimum Flutter version support adjusted to match Dart SDK.
+* Example project: Upgraded SDK and dependencies for compatibility with latest Flutter/Dart.
+* Improved documentation and example code in `example/lib/main.dart`.
+* Cleaned up and updated package metadata in pubspec.yaml.
+* Internal: Refactored and updated supporting files for consistency with latest Flutter project structure.
+
 ## [1.0.5] - 17 October 2022
 ### Release Notes:
 * Updated Documentation

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,21 +22,18 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
+    namespace "com.example.example"
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {
@@ -66,6 +64,3 @@ flutter {
     source '../..'
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-}

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.6.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()
@@ -26,6 +13,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register("clean", Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,11 +1,24 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.6.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+include ":app"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,3 @@
-/// Ensure you use the below two packages in the file which you are working on
 import 'package:flutter/material.dart';
 import 'package:mb_button/mb_button.dart';
 
@@ -9,7 +8,7 @@ void main() {
 
 /// Base for the whole app.
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +25,7 @@ class MyApp extends StatelessWidget {
 
 /// MBButton Demo class show the demo of the usage of this package - `mb_button`.
 class MBButtonDemo extends StatefulWidget {
-  const MBButtonDemo({Key? key, this.title}) : super(key: key);
+  const MBButtonDemo({super.key, this.title});
 
   final String? title;
 
@@ -69,7 +68,7 @@ class _MBButtonDemoState extends State<MBButtonDemo> {
               text: "Add",
               onTapFunction: _incrementCounter,
               textColor: Colors.white,
-              buttonColor: Colors.black12,
+              buttonColor: Colors.cyan,
               verticalPadding: 40,
               horizontalPadding: 40,
               roundness: 50,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,16 +5,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.19.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -24,48 +26,53 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "6.0.0"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "6.1.0"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.11.1"
   mb_button:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.5"
+    version: "3.0.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.17.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.0"
 sdks:
-  dart: ">=2.18.2 <3.0.0"
+  dart: ">=3.10.7 <4.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,10 +4,10 @@ description: A new Flutter project to demonstrate this package(mb_button).
 
 publish_to: 'none'
 
-version: 1.0.0+1
+version: 3.0.0+1
 
 environment:
-  sdk: '>=2.18.2 <3.0.0'
+  sdk: ^3.10.7
 
 dependencies:
   flutter:
@@ -16,7 +16,7 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true

--- a/lib/icon_button.dart
+++ b/lib/icon_button.dart
@@ -29,12 +29,12 @@ class MBElevatedIconButton extends StatefulWidget {
   final IconData icon;
 
   /// [text] is the value of the text which is displayed on [MBElevatedIconButton].
-  /// This is the [required] field, so there is no default value to it.
+  /// This is the required field, so there is no default value to it.
   final String text;
 
   /// [onTapFunction] is the function which [MBElevatedIconButton] has to do
   /// when the [MBButton] is tapped.
-  /// This is also the [required] field, so there is no default value to it.
+  /// This is also the required field, so there is no default value to it.
   final Function()? onTapFunction;
 
   /// Without [icon],[text] and [onTapFunction] a [MBElevatedButton] doesn't exist.

--- a/lib/mb_button.dart
+++ b/lib/mb_button.dart
@@ -75,7 +75,7 @@ class MBButton extends StatefulWidget {
 
   /// [onTapFunction] is the function which [MBElevatedIconButton] has to do
   /// when the [MBButton] is tapped.
-  /// This is also the [required] field, so there is no default value to it.
+  /// This is also the required field, so there is no default value to it.
   final Function() onTapFunction;
 
   /// [MBButton] decides it's child with the [isIconButton] value.
@@ -115,13 +115,13 @@ class _MBButtonState extends State<MBButton> {
 
       /// Default splashColor is Colors.blue with 0.5 opacity
       splashColor: widget.buttonColor != null
-          ? widget.buttonColor!.withOpacity(0.5)
-          : Colors.blue.withOpacity(0.5),
+          ? widget.buttonColor!.withValues(alpha: 0.5)
+          : Colors.blue.withValues(alpha: 0.5),
 
       /// Default hoverColor is Colors.blue with 0.5 opacity
       hoverColor: widget.buttonColor != null
-          ? widget.buttonColor!.withOpacity(0.5)
-          : Colors.blue.withOpacity(0.5),
+          ? widget.buttonColor!.withValues(alpha: 0.5)
+          : Colors.blue.withValues(alpha: 0.5),
 
       /// Default hoverColor is Colors.blue
       buttonColor: widget.buttonColor ?? Colors.blue,

--- a/lib/text_button.dart
+++ b/lib/text_button.dart
@@ -24,12 +24,12 @@ class MBElevatedButton extends StatefulWidget {
   final Color? textColor;
 
   /// [text] is the value of the text which is displayed on [MBElevatedButton].
-  /// This is the [required] field, so there is no default value to it.
+  /// This is a required field, so there is no default value to it.
   final String text;
 
   /// [onTapFunction] is the function which [MBElevatedButton] has to do
   /// when the [MBButton] is tapped.
-  /// This is also the [required] field, so there is no default value to it.
+  /// This is also a required field, so there is no default value to it.
   final Function() onTapFunction;
 
   /// Without [text] and [onTapFunction] a [MBElevatedButton] doesn't exist.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,16 +5,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.19.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -24,41 +26,46 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "6.0.0"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "6.1.0"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.17.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.0"
 sdks:
-  dart: ">=2.18.2 <3.0.0"
+  dart: ">=3.10.7 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,17 +6,17 @@ homepage: https://github.com/moulibheemaneti/mb_button.git
 
 repository: https://github.com/moulibheemaneti/mb_button.git
 
-version: 1.0.5
+version: 3.0.0
 
 environment:
-  sdk: '>=2.18.2 <3.0.0'
+  sdk: ^3.10.7
 
 dependencies:
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flutter_lints: ^2.0.1
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
1. Bump package to v3.0.0 and migrate project to newer Dart/Flutter and Android toolchain. 
2. Update pubspec.yaml (root and example) to SDK ^3.10.7, bump package version, and refresh example dependencies and lint rules. 
3. Migrate Android example to Gradle 8.7 and modern plugin management (Java 11, updated plugin declarations, clean task registration, gradle wrapper), and adjust example code and library docs/usage (minor API/formatting updates such as super.key and color/opacity usage). 
4. BREAKING: requires Dart 3 / matching Flutter toolchain.
5. Update CHANGELOG with 3.0.0 release notes. 