### PR TITLE
Bump SDK to 3.10.8, add lints, update README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Current release
 
+## [3.0.2] - 07 February 2026
+### Release Notes:
+* Increased minimum Flutter SDK version to 3.10.8 in `pubspec.yaml`.
+* Revised and improved `README.md` for clarity.
+* Cleaned up: removed unnecessary comments from codebase.
+
 ## [3.0.1] - 01 February 2026
 ### Release Notes:
 * Updated package version to 3.0.1.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ This is not the last package from this developer. Maybe this solely can't be upd
 
 ## Meet the developer
 **Mouli Bheemaneti** is the developer behind this [mb_button](https://pub.dev/packages/mb_button) package. I'm ambitious and driven towards developing new apps and packages.
-* [Mouli Bheemaneti](https://www.moulibheemaneti.com)
-	* [Play Store](https://play.google.com/store/apps/dev?id=5025838786028729109)
-	* [Github](https://www.github.com/moulibheemaneti)
-	* [Behance](https://www.behance.com/moulibheemaneti)
-	* [Instagram](https://www.instagram.com/mouli.bheemaneti)
-	* [Youtube](https://www.youtube.com/bemouli)
+* [Mouli Bheemaneti](https://developer.moulibheemaneti.com) 
+	* [Github](https://www.github.com/moulibheemaneti)  
+	* [Behance](https://www.behance.com/moulibheemaneti)  

--- a/analysis_options.yml
+++ b/analysis_options.yml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -52,7 +52,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.0.2"
   meta:
     dependency: transitive
     description:
@@ -75,4 +75,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=3.10.7 <4.0.0"
+  dart: ">=3.10.8 <4.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,10 +4,10 @@ description: A new Flutter project to demonstrate this package(mb_button).
 
 publish_to: 'none'
 
-version: 3.0.1+1
+version: 3.0.2+1
 
 environment:
-  sdk: ^3.10.7
+  sdk: ^3.10.8
 
 dependencies:
   flutter:

--- a/lib/icon_button.dart
+++ b/lib/icon_button.dart
@@ -1,4 +1,3 @@
-/// [MBElevatedIconButton] is called when the [isIconButton] of [MBButton] is set to true.
 import 'package:flutter/material.dart';
 
 /// [MBElevatedIconButton] is a [StatefulWidget] which takes [elevation],

--- a/lib/text_button.dart
+++ b/lib/text_button.dart
@@ -1,4 +1,3 @@
-/// [MBElevatedButton] is called when the [isIconButton] of [MBButton] is set to false.
 import 'package:flutter/material.dart';
 
 /// [MBElevatedButton] is a [StatefulWidget] which takes [elevation],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -68,4 +68,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=3.10.7 <4.0.0"
+  dart: ">=3.10.8 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,10 +6,10 @@ homepage: https://github.com/moulibheemaneti/mb_button.git
 
 repository: https://github.com/moulibheemaneti/mb_button.git
 
-version: 3.0.1
+version: 3.0.2
 
 environment:
-  sdk: ^3.10.7
+  sdk: ^3.10.8
 
 dependencies:
   flutter:


### PR DESCRIPTION
Bump package version to 3.0.2 and raise Dart SDK constraint to ^3.10.8 across pubspecs. Add analysis_options.yml to enable flutter_lints. Update README developer links (switch to developer.moulibheemaneti.com and remove several social links). Remove stray top-line doc comments from lib/icon_button.dart and lib/text_button.dart as minor cleanup. Update example and lock files to reflect the version/SDK changes.